### PR TITLE
Add custom 404 page support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,3 +13,4 @@ WORKDIR /payidorg
 
 FROM nginx:1.17-alpine
 COPY --from=0 /payidorg/public /usr/share/nginx/html
+COPY files/default.conf /etc/nginx/conf.d/default.conf

--- a/files/default.conf
+++ b/files/default.conf
@@ -44,4 +44,5 @@ server {
     #location ~ /\.ht {
     #    deny  all;
     #}
+    #
 }

--- a/files/default.conf
+++ b/files/default.conf
@@ -1,0 +1,47 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    error_page  404              /404.html;
+    location = /404.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}

--- a/files/default.conf
+++ b/files/default.conf
@@ -44,5 +44,4 @@ server {
     #location ~ /\.ht {
     #    deny  all;
     #}
-    #
 }


### PR DESCRIPTION
## High Level Overview of Change

The 404 pages weren't set up in nginx. This PR fixes that.
